### PR TITLE
Change Content-Type to 'application/json'

### DIFF
--- a/src/main/asciidoc/_chapters/external_apis.adoc
+++ b/src/main/asciidoc/_chapters/external_apis.adoc
@@ -347,8 +347,8 @@ parameter with syntax like `-d @filename.txt`.
   "http://example.com:8000/users/fakerow"
 
 curl -vi -X PUT \
-  -H "Accept: text/json" \
-  -H "Content-Type: text/json" \
+  -H "Accept: application/json" \
+  -H "Content-Type: application/json" \
   -d '{"Row":[{"key":"cm93NQo=", "Cell": [{"column":"Y2Y6ZQo=", "$":"dmFsdWU1Cg=="}]}]}'' \
   "example.com:8000/users/fakerow"
 


### PR DESCRIPTION
I believe we should be using 'application/json' instead of 'text/json' for Content-Type:

> curl -vi -X PUT -H "Accept: text/json" -H "Content-Type: text/json" -d '{"Row":[{"key":"cm93NQo=", "Cell": [{"column":"Y2Y6ZQo=", "$":"dmFsdWU1Cg=="}]}]}' "http://127.0.0.1:21210/users/fakerow"
HTTP/1.1 415 Unsupported Media Type

> curl -vi -X PUT -H "Accept: text/json" -H "Content-Type: application/json" -d '{"Row":[{"key":"cm93NQo=", "Cell": [{"column":"Y2Y6ZQo=", "$":"dmFsdWU1Cg=="}]}]}' "http://127.0.0.1:21210/users/fakerow"
HTTP/1.1 200 OK

Note: The Accept header "text/json" was only changed for consistency, but it works.